### PR TITLE
Feature/dev 197 - Encriptar evaluaciones + horario en fechas

### DIFF
--- a/front/src/assets/css/sass/_trida.style.scss
+++ b/front/src/assets/css/sass/_trida.style.scss
@@ -9383,3 +9383,7 @@ div.rendered-file-browser{
 .margin-left-1 {
   margin-left: 1rem !important;
 }
+
+.react-datepicker {
+  display: flex !important;
+}

--- a/front/src/components/card-tabs.js
+++ b/front/src/components/card-tabs.js
@@ -20,6 +20,8 @@ import Calendario from './common/Calendario';
 import moment from 'moment';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
+import * as CryptoJS from 'crypto-js';
+import { secretKey } from 'constants/defaultValues';
 
 class CardTabs extends Component {
   constructor(props) {
@@ -67,7 +69,12 @@ class CardTabs extends Component {
 
   handleClickChangeFinalDate = async (date) => {
     if (date) {
-      const obj = { fecha_finalizacion: date.format('YYYY-MM-DD') };
+      const obj = {
+        fecha_finalizacion: CryptoJS.AES.encrypt(
+          date.format('YYYY-MM-DD'),
+          secretKey
+        ).toString(),
+      };
       await editDocument('evaluaciones', this.props.item.id, obj, 'Evaluación');
       this.props.updateEvaluaciones(this.props.materiaId);
     }
@@ -75,7 +82,12 @@ class CardTabs extends Component {
 
   handleClickChangePublicationDate = async (date) => {
     if (date) {
-      const obj = { fecha_publicacion: date.format('YYYY-MM-DD') };
+      const obj = {
+        fecha_publicacion: CryptoJS.AES.encrypt(
+          date.format('YYYY-MM-DD'),
+          secretKey
+        ).toString(),
+      };
       await editDocument('evaluaciones', this.props.item.id, obj, 'Evaluación');
       this.props.updateEvaluaciones(this.props.materiaId);
     }

--- a/front/src/components/card-tabs.js
+++ b/front/src/components/card-tabs.js
@@ -71,7 +71,7 @@ class CardTabs extends Component {
     if (date) {
       const obj = {
         fecha_finalizacion: CryptoJS.AES.encrypt(
-          date.format('YYYY-MM-DD'),
+          date.format('YYYY-MM-DD, HH:mm'),
           secretKey
         ).toString(),
       };
@@ -84,7 +84,7 @@ class CardTabs extends Component {
     if (date) {
       const obj = {
         fecha_publicacion: CryptoJS.AES.encrypt(
-          date.format('YYYY-MM-DD'),
+          date.format('YYYY-MM-DD, HH:mm'),
           secretKey
         ).toString(),
       };
@@ -164,7 +164,7 @@ class CardTabs extends Component {
                             </Colxx>
                             <Colxx lg="4">
                               <Row className="dropdown-calendar">
-                                <p>Fecha de Finalización&nbsp;</p>
+                                <p>Fecha y Hora de Finalización&nbsp;</p>
                                 {rol === ROLES.Docente && (
                                   <Calendario
                                     handleClick={
@@ -172,13 +172,18 @@ class CardTabs extends Component {
                                     }
                                     text="Modificar fecha de evaluación"
                                     evalCalendar={true}
+                                    dateFormat={'DD/MM/YYYY - HH:mm'}
+                                    timeCaption="Hora"
+                                    timeIntervals={60}
+                                    timeFormat={'HH:mm'}
                                   />
                                 )}
                                 {data.base.fecha_finalizacion && (
                                   <p className="mb-4">
                                     {moment(
-                                      data.base.fecha_finalizacion
-                                    ).format('DD/MM/YYYY')}
+                                      data.base.fecha_finalizacion,
+                                      'YYYY-MM-DD, HH:mm'
+                                    ).format('DD/MM/YYYY - HH:mm')}
                                   </p>
                                 )}
                                 {!data.base.fecha_finalizacion && (
@@ -186,7 +191,7 @@ class CardTabs extends Component {
                                 )}
                               </Row>
                               <Row className="dropdown-calendar">
-                                <p>Fecha de Publicación&nbsp;</p>
+                                <p>Fecha y Hora de Publicación&nbsp;</p>
                                 {rol === ROLES.Docente && (
                                   <Calendario
                                     handleClick={
@@ -194,13 +199,18 @@ class CardTabs extends Component {
                                     }
                                     text="Modificar fecha de publicación"
                                     evalCalendar={true}
+                                    dateFormat={'DD/MM/YYYY - HH:mm'}
+                                    timeCaption="Hora"
+                                    timeIntervals={60}
+                                    timeFormat={'HH:mm'}
                                   />
                                 )}
                                 {data.base.fecha_publicacion && (
                                   <p className="mb-4">
-                                    {moment(data.base.fecha_publicacion).format(
-                                      'DD/MM/YYYY'
-                                    )}
+                                    {moment(
+                                      data.base.fecha_publicacion,
+                                      'YYYY-MM-DD, HH:mm'
+                                    ).format('DD/MM/YYYY - HH:mm')}
                                   </p>
                                 )}
                                 {!data.base.fecha_publicacion && (

--- a/front/src/components/common/Calendario.js
+++ b/front/src/components/common/Calendario.js
@@ -38,23 +38,31 @@ class Calendario extends React.Component {
   };
 
   render() {
-    const { text, evalCalendar } = this.props;
+    const {
+      text,
+      evalCalendar,
+      dateFormat,
+      timeFormat,
+      timeCaption,
+      timeIntervals,
+    } = this.props;
     const classText = evalCalendar ? '-eval' : '';
     return (
-      <div
-        className={
-          'glyph-icon simple-icon-calendar set-date-action-icon' +
-          classText +
-          ' relative'
-        }
-        onClick={this.handleClick}
-      >
+      <div>
+        <div
+          className={
+            'glyph-icon simple-icon-calendar set-date-action-icon' +
+            classText +
+            ' relative'
+          }
+          onClick={this.handleClick}
+        ></div>
         <DropdownMenu
           className={'dropdown-menu-calendar ' + this.state.close}
           right
           id="iconMenuDropdown"
         >
-          <ModalHeader>
+          <ModalHeader className="margin-auto">
             <p className="mb-1">{text}</p>
           </ModalHeader>
           <DatePicker
@@ -64,15 +72,23 @@ class Calendario extends React.Component {
             selected={this.state.fecha}
             onChange={this.handleChange}
             peekNextMonth={true}
+            dateFormat={dateFormat ? dateFormat : 'DD/MM/YYYY'}
+            showTimeSelect={timeFormat ? true : false}
+            timeFormat={timeFormat ? timeFormat : null}
+            timeCaption={timeCaption ? timeCaption : null}
+            timeIntervals={timeIntervals ? timeIntervals : null}
             dropdownMode="select"
-            dateFormat="DD/MM/YYYY"
             defaultValue={null}
           />
           <ModalFooter>
-            <Button color="primary" onClick={this.onConfirm}>
+            <Button color="primary" className="button" onClick={this.onConfirm}>
               Confirmar
             </Button>
-            <Button color="primary" onClick={this.handleClick}>
+            <Button
+              color="primary"
+              className="button"
+              onClick={this.handleClick}
+            >
               Cancelar
             </Button>
           </ModalFooter>

--- a/front/src/containers/form-validations/FormikFields.js
+++ b/front/src/containers/form-validations/FormikFields.js
@@ -287,7 +287,11 @@ export class FormikDatePicker extends React.Component {
       <DatePicker
         id={name}
         name={name}
-        dateFormat="DD/MM/YYYY"
+        dateFormat="DD/MM/YYYY - HH:mm"
+        showTimeSelect
+        timeFormat="HH:mm"
+        timeCaption="Hora"
+        timeIntervals={60}
         className={className}
         selected={value}
         onChange={this.handleChange}

--- a/front/src/handlers/DecryptionHandler.js
+++ b/front/src/handlers/DecryptionHandler.js
@@ -1,0 +1,70 @@
+import * as CryptoJS from 'crypto-js';
+import { secretKey } from 'constants/defaultValues';
+
+export const desencriptarEjercicios = (ejercicios) => {
+  let result = ejercicios;
+  for (const ejercicio of result) {
+    ejercicio.data.tipo = CryptoJS.AES.decrypt(
+      ejercicio.data.tipo,
+      secretKey
+    ).toString(CryptoJS.enc.Utf8);
+    ejercicio.data.nombre = CryptoJS.AES.decrypt(
+      ejercicio.data.nombre,
+      secretKey
+    ).toString(CryptoJS.enc.Utf8);
+    ejercicio.data.numero = CryptoJS.AES.decrypt(
+      ejercicio.data.numero.toString(),
+      secretKey
+    ).toString(CryptoJS.enc.Utf8);
+    if (ejercicio.data.consigna)
+      ejercicio.data.consigna = CryptoJS.AES.decrypt(
+        ejercicio.data.consigna,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+    if (ejercicio.data.tema)
+      ejercicio.data.tema = CryptoJS.AES.decrypt(
+        ejercicio.data.tema,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+    if (ejercicio.data.opciones) {
+      for (const opcion of ejercicio.data.opciones) {
+        opcion.opcion = CryptoJS.AES.decrypt(opcion.opcion, secretKey).toString(
+          CryptoJS.enc.Utf8
+        );
+        opcion.verdadera =
+          CryptoJS.AES.decrypt(opcion.verdadera, secretKey).toString(
+            CryptoJS.enc.Utf8
+          ) === 'true';
+      }
+    }
+  }
+  return result;
+};
+
+export const desencriptarEvaluacion = (evaluaciones) => {
+  let result = evaluaciones;
+  result.forEach((evaluacion) => {
+    evaluacion.data.base.descripcion = CryptoJS.AES.decrypt(
+      evaluacion.data.base.descripcion,
+      secretKey
+    ).toString(CryptoJS.enc.Utf8);
+    evaluacion.data.base.nombre = CryptoJS.AES.decrypt(
+      evaluacion.data.base.nombre,
+      secretKey
+    ).toString(CryptoJS.enc.Utf8);
+    evaluacion.data.base.fecha_finalizacion = CryptoJS.AES.decrypt(
+      evaluacion.data.base.fecha_finalizacion,
+      secretKey
+    ).toString(CryptoJS.enc.Utf8);
+    evaluacion.data.base.fecha_publicacion = CryptoJS.AES.decrypt(
+      evaluacion.data.base.fecha_publicacion,
+      secretKey
+    ).toString(CryptoJS.enc.Utf8);
+    if (evaluacion.data.subcollections) {
+      evaluacion.data.subcollections = desencriptarEjercicios(
+        evaluacion.data.subcollections
+      );
+    }
+  });
+  return result;
+};

--- a/front/src/handlers/EncryptionHandler.js
+++ b/front/src/handlers/EncryptionHandler.js
@@ -1,0 +1,40 @@
+import * as CryptoJS from 'crypto-js';
+import { secretKey } from 'constants/defaultValues';
+
+export const encriptarEjercicios = (ejercicios) => {
+  let result = ejercicios;
+  for (const ejercicio of result) {
+    ejercicio.tipo = CryptoJS.AES.encrypt(ejercicio.tipo, secretKey).toString();
+    ejercicio.nombre = CryptoJS.AES.encrypt(
+      ejercicio.nombre,
+      secretKey
+    ).toString();
+    ejercicio.numero = CryptoJS.AES.encrypt(
+      ejercicio.numero.toString(),
+      secretKey
+    ).toString();
+    if (ejercicio.consigna)
+      ejercicio.consigna = CryptoJS.AES.encrypt(
+        ejercicio.consigna,
+        secretKey
+      ).toString();
+    if (ejercicio.tema)
+      ejercicio.tema = CryptoJS.AES.encrypt(
+        ejercicio.tema,
+        secretKey
+      ).toString();
+    if (ejercicio.opciones) {
+      for (const opcion of ejercicio.opciones) {
+        opcion.opcion = CryptoJS.AES.encrypt(
+          opcion.opcion,
+          secretKey
+        ).toString();
+        opcion.verdadera = CryptoJS.AES.encrypt(
+          opcion.verdadera.toString(),
+          secretKey
+        ).toString();
+      }
+    }
+  }
+  return result;
+};

--- a/front/src/helpers/Utils.js
+++ b/front/src/helpers/Utils.js
@@ -101,8 +101,8 @@ export const getFormattedDate = (date) => {
   return moment(date).locale('es').format('DD/MM/YYYY');
 };
 
-/*  Esta función recibe un string con una fecha en formato YYYY-MM-AA y devuelve
+/*  Esta función recibe un string con una fecha, y opcionalmente el formato en el que esta, y devuelve
  un moment de la fecha */
-export const getDate = (date) => {
-  return moment(date).locale('es');
+export const getDate = (date, format) => {
+  return moment(date, format ? format : 'DD/MM/YYYY').locale('es');
 };

--- a/front/src/pages/app/evaluaciones/detalle-evaluacion/editar-evaluacion.js
+++ b/front/src/pages/app/evaluaciones/detalle-evaluacion/editar-evaluacion.js
@@ -7,6 +7,7 @@ import FormEvaluacion from 'pages/app/evaluaciones/form-evaluacion';
 import { getDocumentWithSubCollection } from 'helpers/Firebase-db';
 import * as CryptoJS from 'crypto-js';
 import { secretKey } from 'constants/defaultValues';
+import { desencriptarEjercicios } from 'handlers/DecryptionHandler';
 
 export default class EditarEvaluacion extends Component {
   constructor(props) {
@@ -43,7 +44,7 @@ export default class EditarEvaluacion extends Component {
       descripcion,
     } = data;
 
-    const ejerciciosDesencriptados = this.desencriptarEjercicios(subCollection);
+    const ejerciciosDesencriptados = desencriptarEjercicios(subCollection);
 
     this.setState({
       evaluacionId: id,
@@ -67,47 +68,6 @@ export default class EditarEvaluacion extends Component {
       ),
       isLoading: false,
     });
-  };
-
-  desencriptarEjercicios = (ejercicios) => {
-    let result = ejercicios;
-    for (const ejercicio of result) {
-      ejercicio.data.tipo = CryptoJS.AES.decrypt(
-        ejercicio.data.tipo,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      ejercicio.data.nombre = CryptoJS.AES.decrypt(
-        ejercicio.data.nombre,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      ejercicio.data.numero = CryptoJS.AES.decrypt(
-        ejercicio.data.numero.toString(),
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.consigna)
-        ejercicio.data.consigna = CryptoJS.AES.decrypt(
-          ejercicio.data.consigna,
-          secretKey
-        ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.tema)
-        ejercicio.data.tema = CryptoJS.AES.decrypt(
-          ejercicio.data.tema,
-          secretKey
-        ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.opciones) {
-        for (const opcion of ejercicio.data.opciones) {
-          opcion.opcion = CryptoJS.AES.decrypt(
-            opcion.opcion,
-            secretKey
-          ).toString(CryptoJS.enc.Utf8);
-          opcion.verdadera =
-            CryptoJS.AES.decrypt(opcion.verdadera, secretKey).toString(
-              CryptoJS.enc.Utf8
-            ) === 'true';
-        }
-      }
-    }
-    return result;
   };
 
   onEvaluacionEditada = () => {

--- a/front/src/pages/app/evaluaciones/detalle-evaluacion/editar-evaluacion.js
+++ b/front/src/pages/app/evaluaciones/detalle-evaluacion/editar-evaluacion.js
@@ -5,6 +5,8 @@ import { capitalize } from 'underscore.string';
 import HeaderDeModulo from 'components/common/HeaderDeModulo';
 import FormEvaluacion from 'pages/app/evaluaciones/form-evaluacion';
 import { getDocumentWithSubCollection } from 'helpers/Firebase-db';
+import * as CryptoJS from 'crypto-js';
+import { secretKey } from 'constants/defaultValues';
 
 export default class EditarEvaluacion extends Component {
   constructor(props) {
@@ -41,16 +43,71 @@ export default class EditarEvaluacion extends Component {
       descripcion,
     } = data;
 
+    const ejerciciosDesencriptados = this.desencriptarEjercicios(subCollection);
+
     this.setState({
       evaluacionId: id,
-      nombre: nombre,
+      nombre: CryptoJS.AES.decrypt(nombre, secretKey).toString(
+        CryptoJS.enc.Utf8
+      ),
       fecha_creacion: fecha_creacion,
-      fecha_finalizacion: fecha_finalizacion,
-      fecha_publicacion: fecha_publicacion,
-      descripcion: descripcion,
-      ejercicios: subCollection.sort((a, b) => a.data.numero - b.data.numero),
+      fecha_finalizacion: CryptoJS.AES.decrypt(
+        fecha_finalizacion,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8),
+      fecha_publicacion: CryptoJS.AES.decrypt(
+        fecha_publicacion,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8),
+      descripcion: CryptoJS.AES.decrypt(descripcion, secretKey).toString(
+        CryptoJS.enc.Utf8
+      ),
+      ejercicios: ejerciciosDesencriptados.sort(
+        (a, b) => a.data.numero - b.data.numero
+      ),
       isLoading: false,
     });
+  };
+
+  desencriptarEjercicios = (ejercicios) => {
+    let result = ejercicios;
+    for (const ejercicio of result) {
+      ejercicio.data.tipo = CryptoJS.AES.decrypt(
+        ejercicio.data.tipo,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      ejercicio.data.nombre = CryptoJS.AES.decrypt(
+        ejercicio.data.nombre,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      ejercicio.data.numero = CryptoJS.AES.decrypt(
+        ejercicio.data.numero.toString(),
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.consigna)
+        ejercicio.data.consigna = CryptoJS.AES.decrypt(
+          ejercicio.data.consigna,
+          secretKey
+        ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.tema)
+        ejercicio.data.tema = CryptoJS.AES.decrypt(
+          ejercicio.data.tema,
+          secretKey
+        ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.opciones) {
+        for (const opcion of ejercicio.data.opciones) {
+          opcion.opcion = CryptoJS.AES.decrypt(
+            opcion.opcion,
+            secretKey
+          ).toString(CryptoJS.enc.Utf8);
+          opcion.verdadera =
+            CryptoJS.AES.decrypt(opcion.verdadera, secretKey).toString(
+              CryptoJS.enc.Utf8
+            ) === 'true';
+        }
+      }
+    }
+    return result;
   };
 
   onEvaluacionEditada = () => {

--- a/front/src/pages/app/evaluaciones/detalle-evaluacion/vista-previa-evaluacion.js
+++ b/front/src/pages/app/evaluaciones/detalle-evaluacion/vista-previa-evaluacion.js
@@ -16,6 +16,8 @@ import { TIPO_EJERCICIO } from 'enumerators/tipoEjercicio';
 import RespuestaLibre from 'pages/app/evaluaciones/ejercicios/respuesta-libre';
 import OpcionMultiple from 'pages/app/evaluaciones/ejercicios/opcion-multiple';
 import Oral from 'pages/app/evaluaciones/ejercicios/oral';
+import * as CryptoJS from 'crypto-js';
+import { secretKey } from 'constants/defaultValues';
 
 export default class ModalVistaPreviaEvaluacion extends Component {
   constructor(props) {
@@ -45,12 +47,59 @@ export default class ModalVistaPreviaEvaluacion extends Component {
     const { id, data, subCollection } = evaluacion;
     const { nombre } = data;
 
+    const ejerciciosDesencriptados = this.desencriptarEjercicios(subCollection);
+
     this.setState({
       evaluacionId: id,
-      nombre: nombre,
-      ejercicios: subCollection.sort((a, b) => a.data.numero - b.data.numero),
+      nombre: CryptoJS.AES.decrypt(nombre, secretKey).toString(
+        CryptoJS.enc.Utf8
+      ),
+      ejercicios: ejerciciosDesencriptados.sort(
+        (a, b) => a.data.numero - b.data.numero
+      ),
       isLoading: false,
     });
+  };
+
+  desencriptarEjercicios = (ejercicios) => {
+    let result = ejercicios;
+    for (const ejercicio of result) {
+      ejercicio.data.tipo = CryptoJS.AES.decrypt(
+        ejercicio.data.tipo,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      ejercicio.data.nombre = CryptoJS.AES.decrypt(
+        ejercicio.data.nombre,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      ejercicio.data.numero = CryptoJS.AES.decrypt(
+        ejercicio.data.numero.toString(),
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.consigna)
+        ejercicio.data.consigna = CryptoJS.AES.decrypt(
+          ejercicio.data.consigna,
+          secretKey
+        ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.tema)
+        ejercicio.data.tema = CryptoJS.AES.decrypt(
+          ejercicio.data.tema,
+          secretKey
+        ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.opciones) {
+        for (const opcion of ejercicio.data.opciones) {
+          opcion.opcion = CryptoJS.AES.decrypt(
+            opcion.opcion,
+            secretKey
+          ).toString(CryptoJS.enc.Utf8);
+          opcion.verdadera =
+            CryptoJS.AES.decrypt(opcion.verdadera, secretKey).toString(
+              CryptoJS.enc.Utf8
+            ) === 'true';
+        }
+      }
+    }
+    return result;
   };
 
   render() {

--- a/front/src/pages/app/evaluaciones/detalle-evaluacion/vista-previa-evaluacion.js
+++ b/front/src/pages/app/evaluaciones/detalle-evaluacion/vista-previa-evaluacion.js
@@ -18,6 +18,7 @@ import OpcionMultiple from 'pages/app/evaluaciones/ejercicios/opcion-multiple';
 import Oral from 'pages/app/evaluaciones/ejercicios/oral';
 import * as CryptoJS from 'crypto-js';
 import { secretKey } from 'constants/defaultValues';
+import { desencriptarEjercicios } from 'handlers/DecryptionHandler';
 
 export default class ModalVistaPreviaEvaluacion extends Component {
   constructor(props) {
@@ -47,7 +48,7 @@ export default class ModalVistaPreviaEvaluacion extends Component {
     const { id, data, subCollection } = evaluacion;
     const { nombre } = data;
 
-    const ejerciciosDesencriptados = this.desencriptarEjercicios(subCollection);
+    const ejerciciosDesencriptados = desencriptarEjercicios(subCollection);
 
     this.setState({
       evaluacionId: id,
@@ -59,47 +60,6 @@ export default class ModalVistaPreviaEvaluacion extends Component {
       ),
       isLoading: false,
     });
-  };
-
-  desencriptarEjercicios = (ejercicios) => {
-    let result = ejercicios;
-    for (const ejercicio of result) {
-      ejercicio.data.tipo = CryptoJS.AES.decrypt(
-        ejercicio.data.tipo,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      ejercicio.data.nombre = CryptoJS.AES.decrypt(
-        ejercicio.data.nombre,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      ejercicio.data.numero = CryptoJS.AES.decrypt(
-        ejercicio.data.numero.toString(),
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.consigna)
-        ejercicio.data.consigna = CryptoJS.AES.decrypt(
-          ejercicio.data.consigna,
-          secretKey
-        ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.tema)
-        ejercicio.data.tema = CryptoJS.AES.decrypt(
-          ejercicio.data.tema,
-          secretKey
-        ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.opciones) {
-        for (const opcion of ejercicio.data.opciones) {
-          opcion.opcion = CryptoJS.AES.decrypt(
-            opcion.opcion,
-            secretKey
-          ).toString(CryptoJS.enc.Utf8);
-          opcion.verdadera =
-            CryptoJS.AES.decrypt(opcion.verdadera, secretKey).toString(
-              CryptoJS.enc.Utf8
-            ) === 'true';
-        }
-      }
-    }
-    return result;
   };
 
   render() {

--- a/front/src/pages/app/evaluaciones/ejercicios/agregar-ejercicio.js
+++ b/front/src/pages/app/evaluaciones/ejercicios/agregar-ejercicio.js
@@ -85,6 +85,8 @@ class AgregarEjercicio extends React.Component {
             if (!ejer.opciones.find((x) => x.verdadera === true)) valid = false; //Ninguna verdadera
             if (ejer.opciones.find((x) => !x.opcion)) valid = false; //Alguna sin cargar opcion
             break;
+          default:
+            break;
         }
       }
     }

--- a/front/src/pages/app/evaluaciones/ejercicios/agregar-ejercicio.js
+++ b/front/src/pages/app/evaluaciones/ejercicios/agregar-ejercicio.js
@@ -64,6 +64,7 @@ class AgregarEjercicio extends React.Component {
 
   validateEjercicios = () => {
     let valid = true;
+    if (this.state.ejerciciosSeleccionados.length === 0) return valid;
     this.setState({ submitted: true });
     for (const ejer of this.state.ejerciciosSeleccionados) {
       if (!ejer.tipo) valid = false;
@@ -127,6 +128,7 @@ class AgregarEjercicio extends React.Component {
     this.setState({
       ejerciciosSeleccionados: ejer,
       cant: num,
+      submitted: false,
     });
   };
 
@@ -141,6 +143,7 @@ class AgregarEjercicio extends React.Component {
     this.setState({
       ejerciciosSeleccionados: ejercicios,
       cant: oldCant - 1,
+      submitted: false,
     });
   };
 

--- a/front/src/pages/app/evaluaciones/ejercicios/opcion-multiple.js
+++ b/front/src/pages/app/evaluaciones/ejercicios/opcion-multiple.js
@@ -69,7 +69,7 @@ class OpcionMultiple extends React.Component {
   };
 
   render() {
-    const { opciones, consigna } = this.state;
+    let { opciones, consigna } = this.state;
 
     const { preview } = this.props;
 

--- a/front/src/pages/app/evaluaciones/evaluaciones.js
+++ b/front/src/pages/app/evaluaciones/evaluaciones.js
@@ -11,6 +11,8 @@ import {
   logicDeleteDocument,
   getCollectionWithSubCollections,
 } from 'helpers/Firebase-db';
+import * as CryptoJS from 'crypto-js';
+import { secretKey } from 'constants/defaultValues';
 
 function collect(props) {
   return { data: props.data };
@@ -41,7 +43,77 @@ class Evaluaciones extends Component {
       false,
       'ejercicios'
     );
-    this.dataListRenderer(arrayDeObjetos);
+    const evaluaciones = this.desencriptarEvaluacion(arrayDeObjetos);
+    this.dataListRenderer(evaluaciones);
+  };
+
+  desencriptarEvaluacion = (evaluaciones) => {
+    let result = evaluaciones;
+    result.forEach((evaluacion) => {
+      evaluacion.data.base.descripcion = CryptoJS.AES.decrypt(
+        evaluacion.data.base.descripcion,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      evaluacion.data.base.nombre = CryptoJS.AES.decrypt(
+        evaluacion.data.base.nombre,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      evaluacion.data.base.fecha_finalizacion = CryptoJS.AES.decrypt(
+        evaluacion.data.base.fecha_finalizacion,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      evaluacion.data.base.fecha_publicacion = CryptoJS.AES.decrypt(
+        evaluacion.data.base.fecha_publicacion,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      if (evaluacion.data.subcollections) {
+        evaluacion.data.subcollections = this.desencriptarEjercicios(
+          evaluacion.data.subcollections
+        );
+      }
+    });
+    return result;
+  };
+
+  desencriptarEjercicios = (ejercicios) => {
+    let result = ejercicios;
+    result.forEach((ejercicio) => {
+      ejercicio.data.tipo = CryptoJS.AES.decrypt(
+        ejercicio.data.tipo,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      ejercicio.data.nombre = CryptoJS.AES.decrypt(
+        ejercicio.data.nombre,
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      ejercicio.data.numero = CryptoJS.AES.decrypt(
+        ejercicio.data.numero.toString(),
+        secretKey
+      ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.consigna)
+        ejercicio.data.consigna = CryptoJS.AES.decrypt(
+          ejercicio.data.consigna,
+          secretKey
+        ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.tema)
+        ejercicio.data.tema = CryptoJS.AES.decrypt(
+          ejercicio.data.tema,
+          secretKey
+        ).toString(CryptoJS.enc.Utf8);
+      if (ejercicio.data.opciones) {
+        for (const opcion of ejercicio.data.opciones) {
+          opcion.opcion = CryptoJS.AES.decrypt(
+            opcion.opcion,
+            secretKey
+          ).toString(CryptoJS.enc.Utf8);
+          opcion.verdadera =
+            CryptoJS.AES.decrypt(opcion.verdadera, secretKey).toString(
+              CryptoJS.enc.Utf8
+            ) === 'true';
+        }
+      }
+    });
+    return result;
   };
 
   componentDidMount() {

--- a/front/src/pages/app/evaluaciones/evaluaciones.js
+++ b/front/src/pages/app/evaluaciones/evaluaciones.js
@@ -11,8 +11,6 @@ import {
   logicDeleteDocument,
   getCollectionWithSubCollections,
 } from 'helpers/Firebase-db';
-import * as CryptoJS from 'crypto-js';
-import { secretKey } from 'constants/defaultValues';
 import { desencriptarEvaluacion } from 'handlers/DecryptionHandler';
 
 function collect(props) {

--- a/front/src/pages/app/evaluaciones/evaluaciones.js
+++ b/front/src/pages/app/evaluaciones/evaluaciones.js
@@ -13,6 +13,7 @@ import {
 } from 'helpers/Firebase-db';
 import * as CryptoJS from 'crypto-js';
 import { secretKey } from 'constants/defaultValues';
+import { desencriptarEvaluacion } from 'handlers/DecryptionHandler';
 
 function collect(props) {
   return { data: props.data };
@@ -43,77 +44,8 @@ class Evaluaciones extends Component {
       false,
       'ejercicios'
     );
-    const evaluaciones = this.desencriptarEvaluacion(arrayDeObjetos);
+    const evaluaciones = desencriptarEvaluacion(arrayDeObjetos);
     this.dataListRenderer(evaluaciones);
-  };
-
-  desencriptarEvaluacion = (evaluaciones) => {
-    let result = evaluaciones;
-    result.forEach((evaluacion) => {
-      evaluacion.data.base.descripcion = CryptoJS.AES.decrypt(
-        evaluacion.data.base.descripcion,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      evaluacion.data.base.nombre = CryptoJS.AES.decrypt(
-        evaluacion.data.base.nombre,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      evaluacion.data.base.fecha_finalizacion = CryptoJS.AES.decrypt(
-        evaluacion.data.base.fecha_finalizacion,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      evaluacion.data.base.fecha_publicacion = CryptoJS.AES.decrypt(
-        evaluacion.data.base.fecha_publicacion,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      if (evaluacion.data.subcollections) {
-        evaluacion.data.subcollections = this.desencriptarEjercicios(
-          evaluacion.data.subcollections
-        );
-      }
-    });
-    return result;
-  };
-
-  desencriptarEjercicios = (ejercicios) => {
-    let result = ejercicios;
-    result.forEach((ejercicio) => {
-      ejercicio.data.tipo = CryptoJS.AES.decrypt(
-        ejercicio.data.tipo,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      ejercicio.data.nombre = CryptoJS.AES.decrypt(
-        ejercicio.data.nombre,
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      ejercicio.data.numero = CryptoJS.AES.decrypt(
-        ejercicio.data.numero.toString(),
-        secretKey
-      ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.consigna)
-        ejercicio.data.consigna = CryptoJS.AES.decrypt(
-          ejercicio.data.consigna,
-          secretKey
-        ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.tema)
-        ejercicio.data.tema = CryptoJS.AES.decrypt(
-          ejercicio.data.tema,
-          secretKey
-        ).toString(CryptoJS.enc.Utf8);
-      if (ejercicio.data.opciones) {
-        for (const opcion of ejercicio.data.opciones) {
-          opcion.opcion = CryptoJS.AES.decrypt(
-            opcion.opcion,
-            secretKey
-          ).toString(CryptoJS.enc.Utf8);
-          opcion.verdadera =
-            CryptoJS.AES.decrypt(opcion.verdadera, secretKey).toString(
-              CryptoJS.enc.Utf8
-            ) === 'true';
-        }
-      }
-    });
-    return result;
   };
 
   componentDidMount() {

--- a/front/src/pages/app/evaluaciones/form-evaluacion.js
+++ b/front/src/pages/app/evaluaciones/form-evaluacion.js
@@ -15,6 +15,8 @@ import { Formik, Form, Field } from 'formik';
 import { evaluationSchema } from 'pages/app/evaluaciones/validations';
 import { FormikDatePicker } from 'containers/form-validations/FormikFields';
 import { getDate } from 'helpers/Utils';
+import * as CryptoJS from 'crypto-js';
+import { secretKey } from 'constants/defaultValues';
 
 class FormEvaluacion extends React.Component {
   constructor(props) {
@@ -89,16 +91,25 @@ class FormEvaluacion extends React.Component {
 
   onSubmit = async () => {
     let ejercicios = this.ejerciciosComponentRef.getEjerciciosSeleccionados();
-
+    const ejerciciosEncriptados = this.encriptarEjercicios(ejercicios);
     const obj = {
-      nombre: this.state.nombre,
-      fecha_finalizacion: this.state.fecha_finalizacion,
-      fecha_publicacion: this.state.fecha_publicacion,
-      descripcion: this.state.descripcion,
+      nombre: CryptoJS.AES.encrypt(this.state.nombre, secretKey).toString(),
+      fecha_finalizacion: CryptoJS.AES.encrypt(
+        this.state.fecha_finalizacion,
+        secretKey
+      ).toString(),
+      fecha_publicacion: CryptoJS.AES.encrypt(
+        this.state.fecha_publicacion,
+        secretKey
+      ).toString(),
+      descripcion: CryptoJS.AES.encrypt(
+        this.state.descripcion,
+        secretKey
+      ).toString(),
       idMateria: this.props.idMateria,
       activo: true,
       subcollection: {
-        data: ejercicios,
+        data: ejerciciosEncriptados,
       },
     };
 
@@ -117,12 +128,21 @@ class FormEvaluacion extends React.Component {
   onEdit = async () => {
     try {
       let ejercicios = this.ejerciciosComponentRef.getEjerciciosSeleccionados();
-
+      const ejerciciosEncriptados = this.encriptarEjercicios(ejercicios);
       const obj = {
-        nombre: this.state.nombre,
-        fecha_finalizacion: this.state.fecha_finalizacion,
-        fecha_publicacion: this.state.fecha_publicacion,
-        descripcion: this.state.descripcion,
+        nombre: CryptoJS.AES.encrypt(this.state.nombre, secretKey).toString(),
+        fecha_finalizacion: CryptoJS.AES.encrypt(
+          this.state.fecha_finalizacion,
+          secretKey
+        ).toString(),
+        fecha_publicacion: CryptoJS.AES.encrypt(
+          this.state.fecha_publicacion,
+          secretKey
+        ).toString(),
+        descripcion: CryptoJS.AES.encrypt(
+          this.state.descripcion,
+          secretKey
+        ).toString(),
       };
 
       await editDocument(
@@ -139,7 +159,7 @@ class FormEvaluacion extends React.Component {
         );
       });
 
-      ejercicios.forEach(async (element) => {
+      ejerciciosEncriptados.forEach(async (element) => {
         await addDocument(
           `evaluaciones/${this.state.evaluacionId}/ejercicios`,
           element,
@@ -153,6 +173,47 @@ class FormEvaluacion extends React.Component {
     } catch (err) {
       console.log(err);
     }
+  };
+
+  encriptarEjercicios = (ejercicios) => {
+    let result = ejercicios;
+    for (const ejercicio of result) {
+      ejercicio.tipo = CryptoJS.AES.encrypt(
+        ejercicio.tipo,
+        secretKey
+      ).toString();
+      ejercicio.nombre = CryptoJS.AES.encrypt(
+        ejercicio.nombre,
+        secretKey
+      ).toString();
+      ejercicio.numero = CryptoJS.AES.encrypt(
+        ejercicio.numero.toString(),
+        secretKey
+      ).toString();
+      if (ejercicio.consigna)
+        ejercicio.consigna = CryptoJS.AES.encrypt(
+          ejercicio.consigna,
+          secretKey
+        ).toString();
+      if (ejercicio.tema)
+        ejercicio.tema = CryptoJS.AES.encrypt(
+          ejercicio.tema,
+          secretKey
+        ).toString();
+      if (ejercicio.opciones) {
+        for (const opcion of ejercicio.opciones) {
+          opcion.opcion = CryptoJS.AES.encrypt(
+            opcion.opcion,
+            secretKey
+          ).toString();
+          opcion.verdadera = CryptoJS.AES.encrypt(
+            opcion.verdadera.toString(),
+            secretKey
+          ).toString();
+        }
+      }
+    }
+    return result;
   };
 
   render() {

--- a/front/src/pages/app/evaluaciones/form-evaluacion.js
+++ b/front/src/pages/app/evaluaciones/form-evaluacion.js
@@ -53,16 +53,20 @@ class FormEvaluacion extends React.Component {
     if (!valid) return;
     if (this.state.evaluacionId) {
       this.setState({
-        fecha_finalizacion: values.fecha_finalizacion.format('YYYY-MM-DD'),
-        fecha_publicacion: values.fecha_publicacion.format('YYYY-MM-DD'),
+        fecha_finalizacion: values.fecha_finalizacion.format(
+          'YYYY-MM-DD, HH:mm'
+        ),
+        fecha_publicacion: values.fecha_publicacion.format('YYYY-MM-DD, HH:mm'),
         descripcion: values.descripcion,
         nombre: values.nombre,
         modalEditOpen: !this.state.modalEditOpen,
       });
     } else {
       this.setState({
-        fecha_finalizacion: values.fecha_finalizacion.format('YYYY-MM-DD'),
-        fecha_publicacion: values.fecha_publicacion.format('YYYY-MM-DD'),
+        fecha_finalizacion: values.fecha_finalizacion.format(
+          'YYYY-MM-DD, HH:mm'
+        ),
+        fecha_publicacion: values.fecha_publicacion.format('YYYY-MM-DD, HH:mm'),
         descripcion: values.descripcion,
         nombre: values.nombre,
         modalAddOpen: !this.state.modalAddOpen,
@@ -77,8 +81,14 @@ class FormEvaluacion extends React.Component {
         evaluacionId: this.props.idEval,
         nombre: this.props.evaluacion.nombre,
         fecha_creacion: this.props.evaluacion.fecha_creacion,
-        fecha_finalizacion: getDate(this.props.evaluacion.fecha_finalizacion),
-        fecha_publicacion: getDate(this.props.evaluacion.fecha_publicacion),
+        fecha_finalizacion: getDate(
+          this.props.evaluacion.fecha_finalizacion,
+          'YYYY-MM-DD, HH:mm'
+        ),
+        fecha_publicacion: getDate(
+          this.props.evaluacion.fecha_publicacion,
+          'YYYY-MM-DD, HH:mm'
+        ),
         descripcion: this.props.evaluacion.descripcion,
         ejercicios: this.props.evaluacion.ejercicios,
         creador: userName,
@@ -273,7 +283,7 @@ class FormEvaluacion extends React.Component {
             <Row>
               <Colxx xxs="6">
                 <FormGroup className="mb-3 error-l-150">
-                  <Label>Fecha de Publicación</Label>
+                  <Label>Fecha y Hora de Publicación</Label>
                   <FormikDatePicker
                     name="fecha_publicacion"
                     value={values.fecha_publicacion}
@@ -290,7 +300,7 @@ class FormEvaluacion extends React.Component {
               </Colxx>
               <Colxx xxs="6">
                 <FormGroup className="mb-3 error-l-150">
-                  <Label>Fecha de Finalización</Label>
+                  <Label>Fecha y Hora de Finalización</Label>
                   <FormikDatePicker
                     name="fecha_finalizacion"
                     value={values.fecha_finalizacion}

--- a/front/src/pages/app/evaluaciones/form-evaluacion.js
+++ b/front/src/pages/app/evaluaciones/form-evaluacion.js
@@ -17,6 +17,7 @@ import { FormikDatePicker } from 'containers/form-validations/FormikFields';
 import { getDate } from 'helpers/Utils';
 import * as CryptoJS from 'crypto-js';
 import { secretKey } from 'constants/defaultValues';
+import { encriptarEjercicios } from 'handlers/EncryptionHandler';
 
 class FormEvaluacion extends React.Component {
   constructor(props) {
@@ -101,7 +102,7 @@ class FormEvaluacion extends React.Component {
 
   onSubmit = async () => {
     let ejercicios = this.ejerciciosComponentRef.getEjerciciosSeleccionados();
-    const ejerciciosEncriptados = this.encriptarEjercicios(ejercicios);
+    const ejerciciosEncriptados = encriptarEjercicios(ejercicios);
     const obj = {
       nombre: CryptoJS.AES.encrypt(this.state.nombre, secretKey).toString(),
       fecha_finalizacion: CryptoJS.AES.encrypt(
@@ -138,7 +139,7 @@ class FormEvaluacion extends React.Component {
   onEdit = async () => {
     try {
       let ejercicios = this.ejerciciosComponentRef.getEjerciciosSeleccionados();
-      const ejerciciosEncriptados = this.encriptarEjercicios(ejercicios);
+      const ejerciciosEncriptados = encriptarEjercicios(ejercicios);
       const obj = {
         nombre: CryptoJS.AES.encrypt(this.state.nombre, secretKey).toString(),
         fecha_finalizacion: CryptoJS.AES.encrypt(
@@ -183,47 +184,6 @@ class FormEvaluacion extends React.Component {
     } catch (err) {
       console.log(err);
     }
-  };
-
-  encriptarEjercicios = (ejercicios) => {
-    let result = ejercicios;
-    for (const ejercicio of result) {
-      ejercicio.tipo = CryptoJS.AES.encrypt(
-        ejercicio.tipo,
-        secretKey
-      ).toString();
-      ejercicio.nombre = CryptoJS.AES.encrypt(
-        ejercicio.nombre,
-        secretKey
-      ).toString();
-      ejercicio.numero = CryptoJS.AES.encrypt(
-        ejercicio.numero.toString(),
-        secretKey
-      ).toString();
-      if (ejercicio.consigna)
-        ejercicio.consigna = CryptoJS.AES.encrypt(
-          ejercicio.consigna,
-          secretKey
-        ).toString();
-      if (ejercicio.tema)
-        ejercicio.tema = CryptoJS.AES.encrypt(
-          ejercicio.tema,
-          secretKey
-        ).toString();
-      if (ejercicio.opciones) {
-        for (const opcion of ejercicio.opciones) {
-          opcion.opcion = CryptoJS.AES.encrypt(
-            opcion.opcion,
-            secretKey
-          ).toString();
-          opcion.verdadera = CryptoJS.AES.encrypt(
-            opcion.verdadera.toString(),
-            secretKey
-          ).toString();
-        }
-      }
-    }
-    return result;
   };
 
   render() {


### PR DESCRIPTION
En esta PR se agregan las siguientes funcionalidades:

- Se encriptan los datos y ejercicios de la evaluación. (Salvo campo activo, fecha creacion y modificacion, y id de materia)
- Se agrega selección de Hora en fecha de publicación y finalización
- Se adapta componente Calendario.js para poder utilizarlo con o sin horario 
- Se corrige error de mensaje al crear una evaluación, antes de agregar ejercicios (Detectado por Lauti)

Para probar:

- Ingresar a una materia
- Crear una evaluación (verificar que los campos fecha de publicación y finalización, ahora tienen hora)
- Verificar en la base que los campos hayan sido guardados y encriptados.
- Editar una evaluación, y verificar en la base que los campos se hayan editado encriptados.
- Editar las fechas desde el calendario del listado de evaluaciones, y verificar que se hayan guardado editadas y correctamente.
- Ir a vista previa, y verificar que todo se vea correctamente