### PR TITLE
bugfix/DEV-118: se agrega validacion antes de salir de videollamada

### DIFF
--- a/front/src/pages/app/clases-virtuales/clases/detalle-clase/pagina-videollamada.js
+++ b/front/src/pages/app/clases-virtuales/clases/detalle-clase/pagina-videollamada.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Prompt, useLocation } from 'react-router-dom';
 import { connect } from 'react-redux';
 import Videollamada from 'components/videollamada/videollamada';
 import {
@@ -21,7 +22,7 @@ const PaginaVideollamada = (props) => {
   );
   // este campo sirve para evaluar las opciones habilitadas dependiendo de si es docente o alumno
   const isHost = props.rol !== ROLES.Alumno;
-
+  const location = useLocation();
   const [options, setOptions] = useState({ microfono: true, camara: true });
   const [call, setCall] = useState(false);
   const [llamadaIniciada, setIniciada] = useState(false);
@@ -55,6 +56,14 @@ const PaginaVideollamada = (props) => {
 
   return call ? (
     <>
+      <Prompt
+        message={(location) => {
+          return location.pathname ===
+            `/app/clases-virtuales/mis-clases/detalle-clase/${props.idClase}`
+            ? true
+            : `Estás en una clase! Estás seguro de que querés salir?`;
+        }}
+      />
       <Videollamada
         roomName={room}
         userName={`${props.nombre} ${props.apellido}`}


### PR DESCRIPTION
Para probar: 

Ingresar a una videollamada e intentar navegar a otra parte de la aplicación.
Debe aparecer una alerta en el browser.
Si se navega por las tabs de la clase, la videollamada no se cierra 😄 