### PR TITLE
notificaciones segun materias

### DIFF
--- a/front/src/containers/navegacion/Topnav.Notifications.js
+++ b/front/src/containers/navegacion/Topnav.Notifications.js
@@ -32,7 +32,7 @@ const NotificationItem = ({ leida, contenido, fecha, url }) => {
   );
 };
 
-const TopnavNotifications = ({ user }) => {
+const TopnavNotifications = ({ user, subject }) => {
   const [notifications, setNotificationsOnSnapshot] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -45,6 +45,7 @@ const TopnavNotifications = ({ user }) => {
       arrayNotifications.push({
         leida: docData.leida,
         contenido: docData.contenido,
+        materia: docData.materia,
         fecha: docData.fecha,
         url: docData.url,
         id: docId,
@@ -59,6 +60,9 @@ const TopnavNotifications = ({ user }) => {
     getCollectionOnSnapshotOrderedAndLimited(
       `notificaciones/${user}/listado`,
       onNewNotification,
+      'materia',
+      '==',
+      subject,
       'fecha',
       'desc',
       15

--- a/front/src/containers/navegacion/Topnav.js
+++ b/front/src/containers/navegacion/Topnav.js
@@ -282,7 +282,10 @@ class TopNav extends Component {
               className="header-icon glyph-icon simple-icon-home ml-1"
               to="/app/home"
             />
-            <TopnavNotifications user={this.props.user} />
+            <TopnavNotifications
+              user={this.props.user}
+              subject={this.props.subject.id}
+            />
             <button
               className="header-icon btn btn-empty d-none d-sm-inline-block"
               type="button"

--- a/front/src/helpers/Firebase-db.js
+++ b/front/src/helpers/Firebase-db.js
@@ -537,12 +537,16 @@ export const getCollectionOnSnapshot = async (collection, callback) => {
 export const getCollectionOnSnapshotOrderedAndLimited = async (
   collection,
   callback,
+  filterBy,
+  operator,
+  filter,
   orderBy,
   order,
   limit
 ) => {
   return await firestore
     .collection(collection)
+    .where(filterBy, operator, filter)
     .orderBy(orderBy, order)
     .limit(limit)
     .onSnapshot(callback);

--- a/functions/index.js
+++ b/functions/index.js
@@ -344,6 +344,7 @@ exports.messageRecived = functions.firestore
         contenido: `Tenés un nuevo mensaje de ${message.emisor.nombre}`,
         fecha: admin.firestore.FieldValue.serverTimestamp(),
         url: `/app/comunicaciones/mensajeria`,
+        materia: message.idMateria,
         leida: false
       }
 
@@ -363,6 +364,7 @@ exports.foroCreated = functions.firestore
         contenido: `Se ha creado el foro ${foro.nombre}`,
         fecha: admin.firestore.FieldValue.serverTimestamp(),
         url: `/app/comunicaciones/foro/detalle-foro/${foroId}`,
+        materia: foro.idMateria,
         leida: false
       };
 
@@ -388,6 +390,7 @@ exports.classCreated = functions.firestore
         contenido: `Se ha creado la clase ${clase.nombre}`,
         fecha: admin.firestore.FieldValue.serverTimestamp(),
         url: `/app/clases-virtuales/mis-clases/detalle-clase/${claseId}`,
+        materia: clase.idMateria,
         leida: false
       };
 
@@ -418,6 +421,7 @@ exports.correctionCreated = functions.firestore
         contenido: `${usuarioObj.nombre} ha entregado una ${correccion.tipo}`,
         fecha: admin.firestore.FieldValue.serverTimestamp(),
         url: `/app/correcciones#${correccionId}`,
+        materia: correccion.idMateria,
         leida: false
       };
 
@@ -465,6 +469,7 @@ exports.contentCreated = functions.storage
           contenido: `Se han cargado nuevos contenidos`,
           fecha: admin.firestore.FieldValue.serverTimestamp(),
           url: `/app/contenidos`,
+          materia: values[1],
           leida: false
         };
 
@@ -491,6 +496,7 @@ exports.contentCreated = functions.storage
         contenido: `Se ha creado la evaluación ${evaluacionNombre}`,
         fecha: evaluacion.fecha_publicacion,
         url: `/app/evaluaciones/escritas#${evaluacionId}`,
+        materia: evaluacion.idMateria,
         leida: false,
         id: evaluacionId
       };
@@ -564,6 +570,7 @@ exports.contentCreated = functions.storage
         contenido: `Se ha creado la práctica ${practica.nombre}`,
         fecha: timeStamp.fromDate(new Date(newValue.fechaLanzada + 'T11:22:33+0000')),
         url: `/app/practicas#${practicaId}`,
+        materia: practica.idMateria,
         leida: false,
         id: practicaId
       };
@@ -636,6 +643,7 @@ exports.contentCreated = functions.storage
         contenido: `Tenés un nuevo comunicado formal de ${message.emisor.nombre}`,
         fecha: admin.firestore.FieldValue.serverTimestamp(),
         url: `/app/comunicaciones/formales#${messageId}`,
+        materia: message.idMateria,
         leida: false
       }
 
@@ -655,6 +663,7 @@ exports.contentCreated = functions.storage
         contenido: `Se ha creado la evaluación oral ${evaluation.nombre}`,
         fecha: admin.firestore.FieldValue.serverTimestamp(),
         url: `/app/evaluaciones/orales#${evaluationId}`,
+        materia: evaluation.idMateria,
         leida: false
       }
 


### PR DESCRIPTION
En esta PR se corrige como se muestran las notificaciones. Ahora se muestran según la materia en la que estés parado.
Para probar, crear foro, clase, enviar mensaje, evaluación .. lo que sea de varias materias distintas y verificar que sólo se muestren las correspondientes a la materia en la que está parado. El usuario de thomi.reynoso@hotmail.com pertenece a matematica de ntra sra del pilar y a institución directiva. Se puede usar micaeladerito@gmail.com y trida.app@gmail.com