### PR TITLE
fix: tab respuestas

### DIFF
--- a/front/src/components/videollamada/ContestarPregunta.js
+++ b/front/src/components/videollamada/ContestarPregunta.js
@@ -44,19 +44,28 @@ class ContestarPregunta extends Component {
     });
   }
 
-  onEjercicioChange = (e, numero) => {
+  onEjercicioChange = (e, numero, respuestaUnica = false) => {
     //Si selecciona una opción, lo coloco en el array
-    if (e.respuesta) {
+
+    if (respuestaUnica) {
+      // pregunta de una sola opcion
       this.setState({
-        respuestas: this.state.respuestas.concat(e.indiceOpcion),
+        respuestas: [e.indiceOpcion],
       });
     } else {
-      // si la deselecciona, lo saco del array
-      this.setState({
-        respuestas: this.state.respuestas.filter(
-          (rta) => rta !== e.indiceOpcion
-        ),
-      });
+      // es multiple choice
+      if (e.respuesta) {
+        this.setState({
+          respuestas: this.state.respuestas.concat(e.indiceOpcion),
+        });
+      } else {
+        // si la deselecciona, lo saco del array
+        this.setState({
+          respuestas: this.state.respuestas.filter(
+            (rta) => rta !== e.indiceOpcion
+          ),
+        });
+      }
     }
   };
 

--- a/front/src/pages/app/clases-virtuales/clases/detalle-clase/respuestas-a-preguntas.js
+++ b/front/src/pages/app/clases-virtuales/clases/detalle-clase/respuestas-a-preguntas.js
@@ -102,7 +102,6 @@ const RespuestasAPreguntas = ({
         const alumnosSinRespuesta = await getAlumnosSinRespuesta(
           alumnosContestaron
         );
-        console.log();
         resumen.push({
           id: preg.id,
           consigna: preg.data.base.consigna,

--- a/front/src/pages/app/clases-virtuales/clases/detalle-clase/respuestas-a-preguntas.js
+++ b/front/src/pages/app/clases-virtuales/clases/detalle-clase/respuestas-a-preguntas.js
@@ -21,6 +21,7 @@ const RespuestasAPreguntas = ({
   isLoading,
   idClase,
   rolDocente,
+  rolAlumno,
   user,
   idMateria,
 }) => {
@@ -28,6 +29,7 @@ const RespuestasAPreguntas = ({
   const [isLoadingLocal, setIsLoadingLocal] = useState(isLoading);
   const [respuestasDeAlumno, setRespuestasDeAlumno] = useState([]);
   const [tooltipOpen, setTooltip] = useState(false);
+  const [alumnosContestaronState, setAlumnosContestaronState] = useState([]);
 
   useEffect(() => {
     getPreguntasConRespuestasDeAlumnos();
@@ -72,6 +74,8 @@ const RespuestasAPreguntas = ({
   };
 
   const crearCantRespuestasPorPregunta = async (preguntasConRespuestas) => {
+    setAlumnosContestaronState([]);
+    const alumnosContestaronStateAux = [];
     const resumen = [];
     if (preguntasConRespuestas.length > 0) {
       for (const preg of preguntasConRespuestas) {
@@ -102,6 +106,7 @@ const RespuestasAPreguntas = ({
         const alumnosSinRespuesta = await getAlumnosSinRespuesta(
           alumnosContestaron
         );
+        alumnosContestaronStateAux.push(alumnosContestaron);
         resumen.push({
           id: preg.id,
           consigna: preg.data.base.consigna,
@@ -113,6 +118,7 @@ const RespuestasAPreguntas = ({
           seLanzo: preg.data.base.seLanzo,
         });
       }
+      setAlumnosContestaronState(alumnosContestaronStateAux);
       setRespuestasPorPregunta(resumen);
       setIsLoadingLocal(false);
     }
@@ -183,7 +189,7 @@ const RespuestasAPreguntas = ({
 
       {respuestasPorPregunta.map((rta, idx) => {
         return (
-          rta.seLanzo && (
+          ((rta.seLanzo && rolAlumno) || rolDocente) && (
             <Card key={idx} className="h-100 card-respuestas">
               <CardBody>
                 <CardTitle>{rta.consigna}</CardTitle>
@@ -194,7 +200,9 @@ const RespuestasAPreguntas = ({
                         {rta.opciones[index]}
                         <span className="float-right text-default">
                           {rta.respuestasVerdaderas.includes(index) &&
-                            rolDocente && (
+                            ((rolAlumno &&
+                              alumnosContestaronState[idx].includes(user)) ||
+                              rolDocente) && (
                               <Badge
                                 color="danger"
                                 pill

--- a/front/src/pages/app/clases-virtuales/clases/detalle-clase/respuestas-a-preguntas.js
+++ b/front/src/pages/app/clases-virtuales/clases/detalle-clase/respuestas-a-preguntas.js
@@ -102,6 +102,7 @@ const RespuestasAPreguntas = ({
         const alumnosSinRespuesta = await getAlumnosSinRespuesta(
           alumnosContestaron
         );
+        console.log();
         resumen.push({
           id: preg.id,
           consigna: preg.data.base.consigna,
@@ -110,6 +111,7 @@ const RespuestasAPreguntas = ({
           respuestasVerdaderas: idxRtasVerdaderas,
           cantTotalRtas: cantTotalRtas,
           alumnosSinRespuesta,
+          seLanzo: preg.data.base.seLanzo,
         });
       }
       setRespuestasPorPregunta(resumen);
@@ -182,59 +184,62 @@ const RespuestasAPreguntas = ({
 
       {respuestasPorPregunta.map((rta, idx) => {
         return (
-          <Card key={idx} className="h-100 card-respuestas">
-            <CardBody>
-              <CardTitle>{rta.consigna}</CardTitle>
-              {rta.resultado.map((opcion, index) => {
-                return (
-                  <div key={index} className="mb-4">
-                    <div className="mb-2">
-                      {rta.opciones[index]}
-                      <span className="float-right text-default">
-                        {rta.respuestasVerdaderas.includes(index) &&
-                          rolDocente && (
-                            <Badge
-                              color="danger"
-                              pill
-                              className="badge-respuestas"
-                            >
-                              Correcta
-                            </Badge>
+          rta.seLanzo && (
+            <Card key={idx} className="h-100 card-respuestas">
+              <CardBody>
+                <CardTitle>{rta.consigna}</CardTitle>
+                {rta.resultado.map((opcion, index) => {
+                  return (
+                    <div key={index} className="mb-4">
+                      <div className="mb-2">
+                        {rta.opciones[index]}
+                        <span className="float-right text-default">
+                          {rta.respuestasVerdaderas.includes(index) &&
+                            rolDocente && (
+                              <Badge
+                                color="danger"
+                                pill
+                                className="badge-respuestas"
+                              >
+                                Correcta
+                              </Badge>
+                            )}
+                          {rolDocente && (
+                            <span>
+                              {opcion}/{rta.cantTotalRtas}
+                            </span>
                           )}
-                        {rolDocente && (
-                          <span>
-                            {opcion}/{rta.cantTotalRtas}
-                          </span>
-                        )}
-                      </span>
+                        </span>
+                      </div>
+                      {rolDocente && (
+                        <Progress value={(opcion / rta.cantTotalRtas) * 100} />
+                      )}
+                      {!rolDocente && (
+                        <Progress
+                          value={
+                            respuestasDeAlumno.some(
+                              (rt) =>
+                                rt.id === rta.id && rt.rtas.includes(index)
+                            )
+                              ? 100
+                              : 0
+                          }
+                        />
+                      )}
                     </div>
-                    {rolDocente && (
-                      <Progress value={(opcion / rta.cantTotalRtas) * 100} />
-                    )}
-                    {!rolDocente && (
-                      <Progress
-                        value={
-                          respuestasDeAlumno.some(
-                            (rt) => rt.id === rta.id && rt.rtas.includes(index)
-                          )
-                            ? 100
-                            : 0
-                        }
-                      />
-                    )}
+                  );
+                })}
+                {rolDocente && !isEmpty(rta.alumnosSinRespuesta) && (
+                  <div>
+                    <span className="font-weight-bold">
+                      Alumnos que no contestaron:{' '}
+                    </span>
+                    {rta.alumnosSinRespuesta}
                   </div>
-                );
-              })}
-              {rolDocente && !isEmpty(rta.alumnosSinRespuesta) && (
-                <div>
-                  <span className="font-weight-bold">
-                    Alumnos que no contestaron:{' '}
-                  </span>
-                  {rta.alumnosSinRespuesta}
-                </div>
-              )}
-            </CardBody>
-          </Card>
+                )}
+              </CardBody>
+            </Card>
+          )
         );
       })}
     </>

--- a/front/src/pages/app/clases-virtuales/clases/detalle-clase/tabs-de-clase.js
+++ b/front/src/pages/app/clases-virtuales/clases/detalle-clase/tabs-de-clase.js
@@ -327,6 +327,7 @@ class TabsDeClase extends Component {
       linksDeClase,
     } = this.state;
     const rolDocente = rol !== ROLES.Alumno;
+    const rolAlumno = rol === ROLES.Alumno;
     return (
       <Row lg="12">
         <Colxx xxs="12" xs="12" lg="12">
@@ -715,6 +716,7 @@ class TabsDeClase extends Component {
                             isLoading={true}
                             idClase={idClase}
                             rolDocente={rolDocente}
+                            rolAlumno={rolAlumno}
                             idMateria={idMateria}
                           />
                         </CardBody>

--- a/front/src/pages/app/clases-virtuales/clases/preguntas-clase/form-preguntas.js
+++ b/front/src/pages/app/clases-virtuales/clases/preguntas-clase/form-preguntas.js
@@ -63,9 +63,14 @@ class FormPreguntas extends React.Component {
   onSubmit = async () => {
     let preguntas = this.ejerciciosComponentRef.getpreguntasRealizadas();
     const preguntasEncriptadas = encriptarEjercicios(preguntas);
+    const preguntasEncriptadasAGuardar = preguntasEncriptadas.map((elem) => ({
+      ...elem,
+      seLanzo: false,
+    }));
+    console.log('preguntasEncriptadasAGuardar', preguntasEncriptadasAGuardar);
     const obj = {
       subcollection: {
-        data: preguntasEncriptadas,
+        data: preguntasEncriptadasAGuardar,
       },
     };
 
@@ -90,7 +95,14 @@ class FormPreguntas extends React.Component {
 
       //encripto preguntas para despues almacenarlas en la DB
       const preguntasEncriptadas = encriptarEjercicios(preguntas);
-
+      const preguntasEncriptadasAGuardar = preguntasEncriptadas.map((elem) => ({
+        ...elem,
+        seLanzo: false,
+      }));
+      console.log(
+        'preguntasEncriptadasAGuardar edit',
+        preguntasEncriptadasAGuardar
+      );
       this.state.preguntas.forEach(async (element) => {
         await deleteDocument(
           `clases/${this.state.idClase}/preguntas`,
@@ -98,7 +110,7 @@ class FormPreguntas extends React.Component {
         );
       });
 
-      preguntasEncriptadas.forEach(async (element) => {
+      preguntasEncriptadasAGuardar.forEach(async (element) => {
         await addDocument(
           `clases/${this.state.idClase}/preguntas`,
           element,

--- a/front/src/pages/app/clases-virtuales/clases/preguntas-clase/form-preguntas.js
+++ b/front/src/pages/app/clases-virtuales/clases/preguntas-clase/form-preguntas.js
@@ -67,7 +67,6 @@ class FormPreguntas extends React.Component {
       ...elem,
       seLanzo: false,
     }));
-    console.log('preguntasEncriptadasAGuardar', preguntasEncriptadasAGuardar);
     const obj = {
       subcollection: {
         data: preguntasEncriptadasAGuardar,
@@ -99,10 +98,6 @@ class FormPreguntas extends React.Component {
         ...elem,
         seLanzo: false,
       }));
-      console.log(
-        'preguntasEncriptadasAGuardar edit',
-        preguntasEncriptadasAGuardar
-      );
       this.state.preguntas.forEach(async (element) => {
         await deleteDocument(
           `clases/${this.state.idClase}/preguntas`,

--- a/front/src/pages/app/evaluaciones/ejercicios/opcion-multiple.js
+++ b/front/src/pages/app/evaluaciones/ejercicios/opcion-multiple.js
@@ -68,7 +68,8 @@ class OpcionMultiple extends React.Component {
     });
     this.props.onEjercicioChange(
       { indiceOpcion: index, respuesta: checked },
-      this.props.value.numero
+      this.props.value.numero,
+      this.props.respuestaUnica
     );
   };
 


### PR DESCRIPTION
En este PR se corrigen algunos bugs encontrados en la tab de respuestas. 

- Se mostraban preguntas en dicha tab que no se habian lanzado previamente, ahora se muestra solo si se lanzaron.
- Se estaba guardando mal la respuesta del alumno de una pregunta de opción única, lo que hacia que se calculen mal los datos mostrados en dicha tab. También, se iban a mostrar mal en reportes de preguntas

Para probar:
- Crear una clase o entrar a una existente que no tenga preguntas.
- Crear preguntas tanto de múltiple como de única selección. Verificar que en la DB se crean con el campo `seLanzo: false`
- Verificar que en la tab de respuestas no se muestra ninguna pregunta (ya que aún no se lanzaron).
- Lanzarlas durante una clase (al menos la de única opción), y contestarlas. 
- Verificar que tanto en la tab de respuestas como en el Reporte de Clase (en _Respuestas a Preguntas Lanzadas en Clases_) se calculan bien los resultados de las rtas. 
- Chequear que:
    - Como docente: muestra TODAS las preguntas (las haya lanzado o no) en la tab de Respuestas
    - Como alumno: muestra SOLO las preguntas que el docente lanzo, y además muestra el _correcta_ **SOLO en aquellas preguntas que el alumno respondió**
- Finalmente, probar que en evaluaciones se guarde todo bien, ya que modifiqué el metodo `onEjercicioChange`, el cual se usa para el componente `OpcionMultiple`